### PR TITLE
Add versions sub command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Commands:
   delete <application> [flags]
     Delete the application
 
+  versions <application> [flags]
+    Manage versions of the application
+
   user <operation> [flags]
     Manage apprun user
 
@@ -229,6 +232,25 @@ local must_env = std.native('must_env');
 ### Delete
 
 `apprun-cli delete app.jsonnet` deletes the application.
+
+### Versions
+
+`apprun-cli versions app.jsonnet` manages the versions of the application.
+
+```
+Flags:
+      --id=STRING    Show the detailed information of the specified version id
+      --delete       Delete the specified version id
+      --force        Force delete without confirmation
+```
+
+If no flags are specified, it shows the list of versions.
+
+`--id` shows the detailed information of the specified version id.
+
+`--delete` deletes the specified version id. Requires `--id` flag.
+
+`--force` forces delete without confirmation. default is false.
 
 ### User
 

--- a/cli.go
+++ b/cli.go
@@ -17,7 +17,7 @@ type CLI struct {
 	Render   RenderOption   `cmd:"" help:"Render application"`
 	Status   StatusOption   `cmd:"" help:"Show status of applications"`
 	Delete   DeleteOption   `cmd:"" help:"Delete the application"`
-	Versions VersionsOption `cmd:"" help:"Show versions of application"`
+	Versions VersionsOption `cmd:"" help:"Manage versions of application"`
 	User     UserOption     `cmd:"" help:"Manage apprun user"`
 
 	Debug bool `help:"Enable debug mode" env:"DEBUG"`

--- a/cli.go
+++ b/cli.go
@@ -10,14 +10,15 @@ import (
 )
 
 type CLI struct {
-	Init   InitOption   `cmd:"" help:"Initialize files from existing application"`
-	Deploy DeployOption `cmd:"" help:"Deploy an application"`
-	List   ListOption   `cmd:"" help:"List applications"`
-	Diff   DiffOption   `cmd:"" help:"Show diff of applications"`
-	Render RenderOption `cmd:"" help:"Render application"`
-	Status StatusOption `cmd:"" help:"Show status of applications"`
-	Delete DeleteOption `cmd:"" help:"Delete the application"`
-	User   UserOption   `cmd:"" help:"Manage apprun user"`
+	Init     InitOption     `cmd:"" help:"Initialize files from existing application"`
+	Deploy   DeployOption   `cmd:"" help:"Deploy an application"`
+	List     ListOption     `cmd:"" help:"List applications"`
+	Diff     DiffOption     `cmd:"" help:"Show diff of applications"`
+	Render   RenderOption   `cmd:"" help:"Render application"`
+	Status   StatusOption   `cmd:"" help:"Show status of applications"`
+	Delete   DeleteOption   `cmd:"" help:"Delete the application"`
+	Versions VersionsOption `cmd:"" help:"Show versions of application"`
+	User     UserOption     `cmd:"" help:"Manage apprun user"`
 
 	Debug bool `help:"Enable debug mode" env:"DEBUG"`
 
@@ -47,6 +48,8 @@ func (c *CLI) Run(ctx context.Context) error {
 		err = c.runList(ctx)
 	case "user <operation>":
 		err = c.runUser(ctx)
+	case "versions <application>":
+		err = c.runVersions(ctx)
 	default:
 		err = fmt.Errorf("unknown command: %s", k.Command())
 	}

--- a/versions.go
+++ b/versions.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/Songmu/prompter"
+	"github.com/sacloud/apprun-api-go"
+	v1 "github.com/sacloud/apprun-api-go/apis/v1"
+)
+
+type VersionsOption struct {
+	Application string `arg:"" name:"application" help:"Name of the definition file to use"`
+	ID          string `help:"Show the detailed information of the specified version id"`
+	Delete      bool   `help:"Delete the specified version id"`
+	Force       bool   `help:"Force delete without confirmation"`
+}
+
+func (c *CLI) runVersions(ctx context.Context) error {
+	opt := c.Versions
+	app, err := LoadApplication(ctx, opt.Application)
+	if err != nil {
+		return err
+	}
+	info, _, err := c.getApplicationByName(ctx, app.Name)
+	if err != nil {
+		return err
+	}
+
+	if opt.ID != "" {
+		return c.runVersionID(ctx, opt, info)
+	}
+
+	for version, err := range c.AllVersions(ctx, v(info.Id)) {
+		if err != nil {
+			return err
+		}
+		fmt.Println(toJSONIndent(version))
+	}
+	return nil
+}
+
+func (c *CLI) runVersionID(ctx context.Context, opt VersionsOption, info *ApplicationInfo) error {
+	op := apprun.NewVersionOp(c.client)
+	if opt.Delete {
+		if !opt.Force && !prompter.YN(fmt.Sprintf("Do you really want to delete version %s of application %s?", opt.ID, *info.Name), false) {
+			slog.Info("canceled")
+			return nil
+		}
+		slog.Info("deleting version", "id", opt.ID, "app", *info.Name)
+		err := op.Delete(ctx, v(info.Id), opt.ID)
+		if err != nil {
+			return fmt.Errorf("failed to delete version: %w", err)
+		}
+		slog.Info("deleted version", "id", opt.ID, "app", *info.Name)
+		return nil
+	}
+	res, err := op.Read(ctx, v(info.Id), opt.ID)
+	if err != nil {
+		return fmt.Errorf("failed to read version: %w", err)
+	}
+	fmt.Println(toJSONIndent(res))
+	return nil
+}
+
+func (c *CLI) AllVersions(ctx context.Context, appId string) func(func(*v1.Version, error) bool) {
+	op := apprun.NewVersionOp(c.client)
+	param := &v1.ListApplicationVersionsParams{
+		SortOrder: ptr(v1.ListApplicationVersionsParamsSortOrder(v1.ListApplicationVersionsParamsSortOrderAsc)),
+		PageSize:  ptr(100),
+	}
+	var page int
+	return func(yield func(*v1.Version, error) bool) {
+		for {
+			page++
+			param.PageNum = ptr(page)
+			slog.Debug("fetching list versions", "app_id", appId, "page", page)
+			res, err := op.List(ctx, appId, param)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			if len(*res.Data) == 0 {
+				return
+			}
+			for _, data := range *res.Data {
+				if !yield(&data, nil) {
+					return
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This pull request introduces a new feature to manage application versions in the `apprun-cli` tool. The main changes include adding a new command for version management, updating the CLI structure, and implementing the necessary functionality to handle version-related operations.

```
Usage: apprun-cli versions <application> [flags]

Show versions of application

Arguments:
  <application>    Name of the definition file to use

Flags:
      --id=STRING    Show the detailed information of the specified version id
      --delete       Delete the specified version id
      --force        Force delete without confirmation
```