### PR TITLE
chore(goreleaser): fix build error

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
-    main: cmd/apprun-cli
+    main: ./cmd/apprun-cli
     binary: apprun-cli
     goos:
       - linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
-    main: cmd/apprun-cli/main.go
+    main: cmd/apprun-cli
     binary: apprun-cli
     goos:
       - linux


### PR DESCRIPTION
As of [v0.2.0](https://github.com/fujiwara/apprun-cli/releases/tag/v0.2.0), the release failed.

v0.2.2: https://github.com/fujiwara/apprun-cli/actions/runs/13336507822/job/37252838561

```
  ⨯ release failed after 1m44s              
    error=
    │ build failed: exit status 1: # command-line-arguments
Error:     │ cmd/apprun-cli/main.go:13:58: undefined: signals
    target=darwin_arm64_v8.0
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.7.0/x64/goreleaser' failed with exit code 1
```

Due to this error, no asset was released. https://github.com/fujiwara/apprun-cli/releases/tag/v0.2.2

<img width="775" alt="image" src="https://github.com/user-attachments/assets/49f49c62-ff3e-4c7b-b524-678a65a7d6ab" />

At v0.2.0, main.go was split into multiple files. 7c63508659373c4eca87d584b79ed26f7815a674 https://github.com/fujiwara/apprun-cli/compare/v0.1.0...v0.2.0

So `go build cmd/apprun-cli/main.go` failed.
Instead, `go build cmd/apprun-cli` should be run.

## Test

`goreleaser release --clean --snapshot` succeeded on my machine (M3 Pro).

```console
$ goreleaser release --clean --snapshot
  • skipping announce, publish, and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=9cdeb6bee24c7c8571c596b4eac182f742ad5df3 branch=chore-fix-build current_tag=v0.2.2 previous_tag=v0.2.1 dirty=false
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=v0.2.2-next
  • running before hooks
    • running                                        hook=go mod download
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/apprun-cli_windows_arm64_v8.0/apprun-cli.exe
    • building                                       binary=dist/apprun-cli_darwin_amd64_v1/apprun-cli
    • building                                       binary=dist/apprun-cli_linux_amd64_v1/apprun-cli
    • building                                       binary=dist/apprun-cli_linux_arm64_v8.0/apprun-cli
    • building                                       binary=dist/apprun-cli_darwin_arm64_v8.0/apprun-cli
    • building                                       binary=dist/apprun-cli_windows_amd64_v1/apprun-cli.exe
  • archives
    • archiving                                      name=dist/apprun-cli_v0.2.2-next_darwin_amd64.tar.gz
    • archiving                                      name=dist/apprun-cli_v0.2.2-next_darwin_arm64.tar.gz
    • archiving                                      name=dist/apprun-cli_v0.2.2-next_linux_arm64.tar.gz
    • archiving                                      name=dist/apprun-cli_v0.2.2-next_windows_arm64.tar.gz
    • archiving                                      name=dist/apprun-cli_v0.2.2-next_windows_amd64.tar.gz
    • archiving                                      name=dist/apprun-cli_v0.2.2-next_linux_amd64.tar.gz
  • calculating checksums
  • writing artifacts metadata
  • release succeeded after 5s
  • thanks for using GoReleaser!
```