### PR TITLE
Show version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,9 @@ builds:
       - CGO_ENABLED=0
     main: ./cmd/apprun-cli
     binary: apprun-cli
+    ldflags:
+      - -s -w
+      - -X main.Version={{.Version}}
     goos:
       - linux
       - darwin

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Flags:
       --debug             Enable debug mode ($DEBUG)
       --app=STRING        Name of the application definition file ($APPRUN_CLI_APP)
       --tfstate=STRING    URL to terraform.tfstate ($APPRUN_CLI_TFSTATE)
+  -v, --version           Show version and exit.
 
 Commands:
   init --name=STRING [flags]

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,44 @@
+inputs:
+  version:
+    description: "A version to install apprun-cli"
+    default: "latest"
+    required: false
+  version-file:
+    description: "File name that contains the apprun-cli version."
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - name: Set apprun-cli version
+      id: set-apprun-cli-version
+      run: |
+        VERSION=${{ inputs.version }}
+        if [ -n "${{ inputs.version-file }}" ]; then
+          VERSION=v$(cat ${{ inputs.version-file }})
+        fi
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Set file name
+      id: set-filename
+      run: |
+        case "${{ runner.os }}" in
+          Linux) BIN_OS="linux" ;;
+          macOS) BIN_OS="darwin" ;;
+          *) BIN_OS="linux" ;;
+        esac
+
+        case "${{ runner.arch }}" in
+          X64) BIN_ARCH="amd64" ;;
+          ARM64) BIN_ARCH="arm64" ;;
+          *) BIN_ARCH="amd64" ;;
+        esac
+
+        FILENAME=apprun-cli_${{ steps.set-apprun-cli-version.outputs.VERSION }}_${BIN_OS}_${BIN_ARCH}.tar.gz
+        echo "FILENAME=$FILENAME" >> $GITHUB_OUTPUT
+      shell: bash
+    - run: |
+        mkdir -p /tmp/apprun-cli-${{ steps.set-apprun-cli-version.outputs.VERSION }}
+        cd /tmp/apprun-cli-${{ steps.set-apprun-cli-version.outputs.VERSION }}
+        curl -sL https://github.com/fujiwara/apprun-cli/releases/download/${{ steps.set-apprun-cli-version.outputs.VERSION }}/${{ steps.set-filename.outputs.FILENAME }} | tar zxvf -
+        sudo install apprun-cli /usr/local/bin
+      shell: bash

--- a/cli.go
+++ b/cli.go
@@ -24,16 +24,17 @@ type CLI struct {
 	Traffics TrafficsOption `cmd:"" help:"Manage traffics of application"`
 	User     UserOption     `cmd:"" help:"Manage apprun user"`
 
-	Debug       bool   `help:"Enable debug mode" env:"DEBUG"`
-	Application string `name:"app" help:"Name of the application definition file" env:"APPRUN_CLI_APP"`
-	TFState     string `name:"tfstate" help:"URL to terraform.tfstate" env:"APPRUN_CLI_TFSTATE"`
+	Debug       bool             `help:"Enable debug mode" env:"DEBUG"`
+	Application string           `name:"app" help:"Name of the application definition file" env:"APPRUN_CLI_APP"`
+	TFState     string           `name:"tfstate" help:"URL to terraform.tfstate" env:"APPRUN_CLI_TFSTATE"`
+	Version     kong.VersionFlag `short:"v" help:"Show version and exit."`
 
 	client *apprun.Client
 	vm     *jsonnet.VM
 }
 
 func (c *CLI) Run(ctx context.Context) error {
-	k := kong.Parse(c)
+	k := kong.Parse(c, kong.Vars{"version": fmt.Sprintf("apprun-cli %s", Version)})
 	var err error
 	if c.Debug {
 		slog.SetLogLoggerLevel(slog.LevelDebug)

--- a/cmd/apprun-cli/main.go
+++ b/cmd/apprun-cli/main.go
@@ -9,7 +9,10 @@ import (
 	cli "github.com/fujiwara/apprun-cli"
 )
 
+var Version = "current"
+
 func main() {
+	cli.Version = Version
 	ctx, stop := signal.NotifyContext(context.Background(), signals()...)
 	defer stop()
 	if err := run(ctx); err != nil {

--- a/main.go
+++ b/main.go
@@ -7,6 +7,8 @@ import (
 	"github.com/sacloud/apprun-api-go"
 )
 
+var Version string
+
 func New(ctx context.Context) (*CLI, error) {
 	c := &CLI{
 		client: &apprun.Client{},


### PR DESCRIPTION
This pull request includes several changes to add versioning support to the `apprun-cli` and enhance the build process. The most important changes include updating the build configuration, adding version flags to the CLI, and modifying the action and main files to handle versioning.

### Versioning support:

* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R10-R12): Added `ldflags` to include version information in the build process.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R19): Added a `--version` flag to display the version and exit.
* [`cli.go`](diffhunk://#diff-8d9ca23280f24fe6444d03ae46e7a15dd152170f32f57f978dfbdfd3cfe8ff55R30-R37): Added a `Version` field to the `CLI` struct and modified the `kong.Parse` call to include version information.
* [`cmd/apprun-cli/main.go`](diffhunk://#diff-b145af06d34d14b3da4c22567b3563bfabaa4255f3cc6e5d09b725c19451aa46R12-R15): Introduced a `Version` variable and assigned it to `cli.Version`.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R10-R11): Added a `Version` variable to be used in the `CLI` struct.

### Action updates:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R1-R44): Added inputs for version and version-file, and steps to set the apprun-cli version and file name dynamically based on the runner's OS and architecture.