### PR TITLE
[Action] inputs.version is required.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,7 @@
 inputs:
   version:
     description: "A version to install apprun-cli"
-    default: "latest"
-    required: false
+    required: true
   version-file:
     description: "File name that contains the apprun-cli version."
     required: false


### PR DESCRIPTION
`latest` should not be used.

refs #29 