### PR TITLE
add url subcommand.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Commands:
   user <operation> [flags]
     Manage apprun user
 
+  url [flags]
+    Show application public URL
+
 Run "apprun-cli <command> --help" for more information on a command.
 ```
 
@@ -289,6 +292,8 @@ local tfs = std.native('tfstate');
 
 `apprun-cli render` shows the rendered application.
 
+`--jsonnet` flag enables Jsonnet format for rendering.
+
 #### Status
 
 `apprun-cli status` shows the status of the application.
@@ -301,6 +306,23 @@ local tfs = std.native('tfstate');
   "public_url": "https://app-e8e32d63-2260-4093-aef2-c277b375de4e.ingress.apprun.sakura.ne.jp",
   "status": "Success"
 }
+```
+
+### URL
+
+`apprun-cli url` shows the public URL of the application.
+
+```console
+$ apprun-cli url
+https://app-example-eacc-44ef-b92d-ab0f65fe8ed4.ingress.apprun.sakura.ne.jp
+```
+
+This URL is also shown in the `public_url` field of the `list` and `status` commands.
+
+This is useful to get the URL in scripts. For example:
+
+```console
+$ curl $(apprun-cli url)
 ```
 
 #### Delete

--- a/cli.go
+++ b/cli.go
@@ -23,6 +23,7 @@ type CLI struct {
 	Versions VersionsOption `cmd:"" help:"Manage versions of application"`
 	Traffics TrafficsOption `cmd:"" help:"Manage traffics of application"`
 	User     UserOption     `cmd:"" help:"Manage apprun user"`
+	URL      struct{}       `cmd:"" help:"Show application public URL"`
 
 	Debug       bool             `help:"Enable debug mode" env:"DEBUG"`
 	Application string           `name:"app" help:"Name of the application definition file" env:"APPRUN_CLI_APP"`
@@ -38,6 +39,9 @@ func (c *CLI) Run(ctx context.Context) error {
 	var err error
 	if c.Debug {
 		slog.SetLogLoggerLevel(slog.LevelDebug)
+	} else if k.Command() == "url" {
+		// suppress info logs for url command
+		slog.SetLogLoggerLevel(slog.LevelWarn)
 	}
 	if err := c.setupVM(ctx); err != nil {
 		return err
@@ -64,6 +68,8 @@ func (c *CLI) Run(ctx context.Context) error {
 		err = c.runVersions(ctx)
 	case "traffics":
 		err = c.runTraffics(ctx)
+	case "url":
+		err = c.runURL(ctx)
 	default:
 		err = fmt.Errorf("unknown command: %s", k.Command())
 	}

--- a/url.go
+++ b/url.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+)
+
+func (c *CLI) runURL(ctx context.Context) error {
+	app, err := c.LoadApplication(ctx, c.Application)
+	if err != nil {
+		return fmt.Errorf("failed to load application: %w", err)
+	}
+	info, _, err := c.getApplicationByName(ctx, app.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get application: %w", err)
+	}
+	fmt.Println(info.PublicUrl)
+	return nil
+}


### PR DESCRIPTION
`apprun-cli url` shows the public URL of the application.

```console
$ apprun-cli url
https://app-example-eacc-44ef-b92d-ab0f65fe8ed4.ingress.apprun.sakura.ne.jp
```

This URL is also shown in the `public_url` field of the `list` and `status` commands.

This is useful to get the URL in scripts. For example:

```console
$ curl $(apprun-cli url)
```
