### PR TITLE
Use sakura-secrets-cli for Secret Manager integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,11 +36,11 @@ This struct is used for:
 ### Jsonnet Integration
 The project uses `fujiwara/jsonnet-armed` for enhanced Jsonnet support with custom native functions defined in `jsonnet.go`. `setupVM()` initializes the Jsonnet VM with:
 1. Default native functions (`must_env`, `env` - from jsonnet-armed)
-2. Secret Manager function (`secret_value(vault_id, secret_name, version)`)
+2. Secret Manager function (`secret(vault_id, name)` from sakura-secrets-cli, plus deprecated `secret_value` wrapper)
 3. Terraform state lookup (`tfstate(path)`) - only when `--tfstate` is specified
 
 ### API Client
-Uses `sacloud/apprun-api-go` for AppRun API interactions and `sacloud/secretmanager-api-go` for Secret Manager. The client is initialized with credentials from environment variables:
+Uses `sacloud/apprun-api-go` for AppRun API interactions and `fujiwara/sakura-secrets-cli` for Secret Manager integration. The client is initialized with credentials from environment variables:
 - `SAKURACLOUD_ACCESS_TOKEN`
 - `SAKURACLOUD_ACCESS_TOKEN_SECRET`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,3 +66,7 @@ The codebase uses Go 1.23+ range-over-func iterators for paginated API results (
 
 ### Traffic Management
 Traffic shifting (`traffics.go`) supports gradual rollout with `--shift-to`, `--rate`, `--period`, and `--rollback-on-failure` flags.
+
+## TODO
+
+- Remove deprecated `secret_value()` Jsonnet function (`deprecatedSecretValueFunc` in jsonnet.go) when releasing v1.

--- a/README.md
+++ b/README.md
@@ -449,15 +449,16 @@ For more information, see [tfstate-lookup](https://github.com/fujiwara/tfstate-l
 ### Lookup secrets from Secret Manager
 
 You can use Jsonnet to read secret values from Sakura Cloud Secret Manager using functions via `std.native`.
+This feature is powered by [sakura-secrets-cli](https://github.com/fujiwara/sakura-secrets-cli).
 
 ```jsonnet
-local secret_value = std.native('secret_value');
+local secret = std.native('secret');
 {
   components: [
     {
       deploy_source: {
         container_registry: {
-          password: secret_value('your-vault-id', 'registry-password', null),
+          password: secret('your-vault-id', 'registry-password'),
         },
       },
     },
@@ -465,10 +466,11 @@ local secret_value = std.native('secret_value');
 }
 ```
 
-- `secret_value(vault_id, secret_name, version)` reads the secret value from Secret Manager.
+- `secret(vault_id, name)` reads the secret value from Secret Manager.
   - `vault_id`: Resource ID of the Secret Manager Vault (string)
-  - `secret_name`: Name of the secret (string)
-  - `version`: Version number of the secret (number or `null` for the latest version)
+  - `name`: Name of the secret (string). To specify a version, use `"name:version"` format (e.g. `"registry-password:1"`)
+
+> **Note:** The legacy `secret_value(vault_id, secret_name, version)` function is still available for backward compatibility but is deprecated. Please migrate to `secret()`.
 
 The Secret Manager API uses the same authentication credentials as AppRun API (`SAKURACLOUD_ACCESS_TOKEN` and `SAKURACLOUD_ACCESS_TOKEN_SECRET`).
 

--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,12 @@ require (
 	github.com/alecthomas/kong v1.14.0
 	github.com/fatih/color v1.18.0
 	github.com/fujiwara/jsonnet-armed v0.1.1
+	github.com/fujiwara/sakura-secrets-cli v0.3.0
 	github.com/fujiwara/tfstate-lookup v1.10.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-jsonnet v0.21.0
 	github.com/itchyny/gojq v0.12.18
 	github.com/sacloud/apprun-api-go v0.6.1
-	github.com/sacloud/saclient-go v0.3.1
-	github.com/sacloud/secretmanager-api-go v0.3.1
 	github.com/schollz/progressbar/v3 v3.19.0
 	golang.org/x/sys v0.42.0
 )
@@ -81,7 +80,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -110,6 +109,8 @@ require (
 	github.com/sacloud/api-client-go v0.3.5 // indirect
 	github.com/sacloud/go-http v0.1.9 // indirect
 	github.com/sacloud/packages-go v0.0.12 // indirect
+	github.com/sacloud/saclient-go v0.3.2 // indirect
+	github.com/sacloud/secretmanager-api-go v0.3.1 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
 	github.com/zeebo/errs v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fujiwara/jsonnet-armed v0.1.1 h1:Lq65mAKzhdVWFLjQowYb4t4RS/1AMA5sXiGWb6HaskM=
 github.com/fujiwara/jsonnet-armed v0.1.1/go.mod h1:MyGurW7aiBjqaRuXb1GsHGr43CbRkMJ8rg0zyYLd2CU=
+github.com/fujiwara/sakura-secrets-cli v0.3.0 h1:dIwj2u+c16ZsSh/DjA2octkW3EHBF61B/5MJnwe48N8=
+github.com/fujiwara/sakura-secrets-cli v0.3.0/go.mod h1:u7wdFkMXan+O8WZO89hA3zZ3DABjKiZZja/nsDsFUfg=
 github.com/fujiwara/tfstate-lookup v1.10.0 h1:RtVV1PUO+C7hqmRKhecS/ed6XOZ4KDiJmbHPFvX7ZJE=
 github.com/fujiwara/tfstate-lookup v1.10.0/go.mod h1:hBwXB7lKy4kPEM+szko7rzAq04TGpBzzNY8Wm8hG6UE=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -172,8 +174,8 @@ github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzw
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
 github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
-github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -211,10 +213,10 @@ github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKe
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/jsonapi v1.4.3-0.20250220162346-81a76b606f3e h1:xwy/1T0cxHWaLx2MM0g4BlaQc1BXn/9835mPrBqwSPU=
 github.com/hashicorp/jsonapi v1.4.3-0.20250220162346-81a76b606f3e/go.mod h1:kWfdn49yCjQvbpnvY1dxxAuAFzISwrrMDQOcu6NsFoM=
-github.com/hashicorp/terraform-plugin-framework v1.17.0 h1:JdX50CFrYcYFY31gkmitAEAzLKoBgsK+iaJjDC8OexY=
-github.com/hashicorp/terraform-plugin-framework v1.17.0/go.mod h1:4OUXKdHNosX+ys6rLgVlgklfxN3WHR5VHSOABeS/BM0=
-github.com/hashicorp/terraform-plugin-go v0.29.0 h1:1nXKl/nSpaYIUBU1IG/EsDOX0vv+9JxAltQyDMpq5mU=
-github.com/hashicorp/terraform-plugin-go v0.29.0/go.mod h1:vYZbIyvxyy0FWSmDHChCqKvI40cFTDGSb3D8D70i9GM=
+github.com/hashicorp/terraform-plugin-framework v1.18.0 h1:Xy6OfqSTZfAAKXSlJ810lYvuQvYkOpSUoNMQ9l2L1RA=
+github.com/hashicorp/terraform-plugin-framework v1.18.0/go.mod h1:eeFIf68PME+kenJeqSrIcpHhYQK0TOyv7ocKdN4Z35E=
+github.com/hashicorp/terraform-plugin-go v0.30.0 h1:VmEiD0n/ewxbvV5VI/bYwNtlSEAXtHaZlSnyUUuQK6k=
+github.com/hashicorp/terraform-plugin-go v0.30.0/go.mod h1:8d523ORAW8OHgA9e8JKg0ezL3XUO84H0A25o4NY/jRo=
 github.com/hashicorp/terraform-plugin-log v0.10.0 h1:eu2kW6/QBVdN4P3Ju2WiB2W3ObjkAsyfBsL3Wh1fj3g=
 github.com/hashicorp/terraform-plugin-log v0.10.0/go.mod h1:/9RR5Cv2aAbrqcTSdNmY1NRHP4E3ekrXRGjqORpXyB0=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
@@ -269,8 +271,8 @@ github.com/sacloud/go-http v0.1.9 h1:Xa5PY8/pb7XWhwG9nAeXSrYXPbtfBWqawgzxD5co3VE
 github.com/sacloud/go-http v0.1.9/go.mod h1:DpDG+MSyxYaBwPJ7l3aKLMzwYdTVtC5Bo63HActcgoE=
 github.com/sacloud/packages-go v0.0.12 h1:MKeZNN3FQn1heqUSRBrbZw89YusZA1n4kammjMFZYvQ=
 github.com/sacloud/packages-go v0.0.12/go.mod h1:XNF5MCTWcHo9NiqWnYctVbASSSZR3ZOmmQORIzcurJ8=
-github.com/sacloud/saclient-go v0.3.1 h1:s9Yx4arEgsoIWkULO9s3gNv03XRGR0eNOQ9z6iI1iWE=
-github.com/sacloud/saclient-go v0.3.1/go.mod h1:OLit87m1GmGwFwlaoQwF2UWyaad4Pa2jfPeVgx91s4s=
+github.com/sacloud/saclient-go v0.3.2 h1:naQow/P7gYP4rozN//I0iCwq5PyzV/3WsK4JIhvtUIo=
+github.com/sacloud/saclient-go v0.3.2/go.mod h1:I9CiH5bYOOu6wgLpdv9yl+JW80qafEFca0VqoSEAYpE=
 github.com/sacloud/secretmanager-api-go v0.3.1 h1:71Bxt/WxtYfilkj35pD5pauy9zYYEQkF09bturYq1jM=
 github.com/sacloud/secretmanager-api-go v0.3.1/go.mod h1:eSMKWniJrPbaOWWv66AJgubXOoR6ZAOt8uIZo/5BJF8=
 github.com/schollz/progressbar/v3 v3.19.0 h1:Ea18xuIRQXLAUidVDox3AbwfUhD0/1IvohyTutOIFoc=

--- a/jsonnet.go
+++ b/jsonnet.go
@@ -3,23 +3,21 @@ package cli
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
+	sscli "github.com/fujiwara/sakura-secrets-cli"
 	"github.com/fujiwara/tfstate-lookup/tfstate"
 	"github.com/google/go-jsonnet"
 	"github.com/google/go-jsonnet/ast"
-	"github.com/sacloud/saclient-go"
-	sm "github.com/sacloud/secretmanager-api-go"
-	v1 "github.com/sacloud/secretmanager-api-go/apis/v1"
 )
 
 func (c *CLI) setupVM(ctx context.Context) error {
 	nativeFuncs := DefaultJsonnetNativeFuncs()
+
 	// load secretmanager functions
-	funcs, err := secretsManagerNativeFuncs(ctx)
-	if err != nil {
-		return err
-	}
-	nativeFuncs = append(nativeFuncs, funcs...)
+	secretFunc := sscli.SecretNativeFunction(ctx)
+	nativeFuncs = append(nativeFuncs, secretFunc)
+	nativeFuncs = append(nativeFuncs, deprecatedSecretValueFunc(secretFunc))
 
 	// load tfstate functions
 	if c.TFState != "" {
@@ -34,47 +32,39 @@ func (c *CLI) setupVM(ctx context.Context) error {
 	return nil
 }
 
-func secretsManagerNativeFuncs(ctx context.Context) ([]*jsonnet.NativeFunction, error) {
-	var sa saclient.Client
-	client, err := sm.NewClient(&sa)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create SecretManager client: %w", err)
-	}
-	return []*jsonnet.NativeFunction{
-		{
-			Name: "secret_value",
-			Params: []ast.Identifier{
-				"vault_id",    // vault_id is a resource ID of SecretManager Vault
-				"secret_name", // secret_name is a name of secret
-				"version",     // version is a version number of secret, null means latest version
-			},
-			Func: func(args []any) (any, error) {
-				vaultID, ok := args[0].(string)
-				if !ok {
-					return nil, fmt.Errorf("vault_id must be a string")
-				}
-				secretName, ok := args[1].(string)
-				if !ok {
-					return nil, fmt.Errorf("secret_name must be a string")
-				}
-				var version v1.OptNilInt
-				if args[2] != nil {
-					v, ok := args[2].(float64)
-					if !ok {
-						return nil, fmt.Errorf("version must be a number")
-					}
-					version = v1.NewOptNilInt(int(v))
-				}
-				secOp := sm.NewSecretOp(client, vaultID)
-				res, err := secOp.Unveil(ctx, v1.Unveil{
-					Name:    secretName,
-					Version: version,
-				})
-				if err != nil {
-					return nil, fmt.Errorf("failed to unveil secret with vault_id: %s secret_name: %s version: %v: %s", vaultID, secretName, args[2], err)
-				}
-				return res.Value, nil
-			},
+// deprecatedSecretValueFunc returns a backward-compatible "secret_value" native function
+// that internally delegates to the "secret" function from sakura-secrets-cli.
+func deprecatedSecretValueFunc(secretFunc *jsonnet.NativeFunction) *jsonnet.NativeFunction {
+	return &jsonnet.NativeFunction{
+		Name: "secret_value",
+		Params: []ast.Identifier{
+			"vault_id",
+			"secret_name",
+			"version",
 		},
-	}, nil
+		Func: func(args []any) (any, error) {
+			vaultID, ok := args[0].(string)
+			if !ok {
+				return nil, fmt.Errorf("vault_id must be a string")
+			}
+			secretName, ok := args[1].(string)
+			if !ok {
+				return nil, fmt.Errorf("secret_name must be a string")
+			}
+			// build name with optional version suffix for the new "secret" function
+			name := secretName
+			if args[2] != nil {
+				v, ok := args[2].(float64)
+				if !ok {
+					return nil, fmt.Errorf("version must be a number")
+				}
+				name = fmt.Sprintf("%s:%d", secretName, int(v))
+			}
+			slog.Warn(
+				"secret_value() is deprecated, use secret() instead",
+				"migrate_to", fmt.Sprintf(`std.native('secret')('%s', '%s')`, vaultID, name),
+			)
+			return secretFunc.Func([]any{vaultID, name})
+		},
+	}
 }


### PR DESCRIPTION
## Summary
- Replace self-implemented `secret_value()` Jsonnet function with `secret()` from `github.com/fujiwara/sakura-secrets-cli`
- Keep `secret_value()` as a deprecated backward-compatible wrapper that logs a migration warning with the equivalent `secret()` call
- Remove direct dependencies on `sacloud/saclient-go` and `sacloud/secretmanager-api-go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)