### PR TITLE
Add link to apprun-dedicated-cli in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 apprun-cli is a command line interface for [AppRun Shared (共用型)](https://manual.sakura.ad.jp/cloud/manual-sakura-apprun.html) on Sakura Cloud.
 
-This is an unofficial tool. Note that AppRun Dedicated (専有型) is a separate service with a different API and is not supported by this tool.
+This is an unofficial tool. Note that AppRun Dedicated (専有型) is a separate service with a different API and is not supported by this tool. For AppRun Dedicated, see [fujiwara/apprun-dedicated-cli](https://github.com/fujiwara/apprun-dedicated-cli).
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Add link to [fujiwara/apprun-dedicated-cli](https://github.com/fujiwara/apprun-dedicated-cli) for AppRun Dedicated (専有型)

🤖 Generated with [Claude Code](https://claude.com/claude-code)