### PR TITLE
Exclude GCS and Azure backends from tfstate-lookup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,14 +13,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go }}
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
 
       - name: Build & Test
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,9 @@ builds:
       - CGO_ENABLED=0
     main: ./cmd/apprun-cli
     binary: apprun-cli
+    tags:
+      - no_gcs
+      - no_azurerm
     ldflags:
       - -s -w
       - -X main.Version=v{{.Version}}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: clean test
 
 build:
-	go build -o apprun-cli ./cmd/apprun-cli
+	go build -tags no_gcs,no_azurerm -o apprun-cli ./cmd/apprun-cli
 
 clean:
 	rm -rf apprun-cli dist/
@@ -10,7 +10,7 @@ test:
 	go test -v ./...
 
 install:
-	go install github.com/fujiwara/apprun-cli/cmd/apprun-cli
+	go install -tags no_gcs,no_azurerm github.com/fujiwara/apprun-cli/cmd/apprun-cli
 
 dist:
 	goreleaser build --snapshot --clean


### PR DESCRIPTION
## Summary

- Add build tags `no_gcs,no_azurerm` to exclude unused Google Cloud Storage and Azure Blob Storage backends from tfstate-lookup
- Applied to Makefile (`build`, `install`) and `.goreleaser.yml` (release builds)
- Fix CI: swap checkout/setup-go order so `go.sum` is available for module cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)