### PR TITLE
Remove GCS and Azure backends from supported tfstate URL schemes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ local tfstate = std.native('tfstate');
 $ apprun-cli deploy --app app.jsonnet --tfstate https://example.com/terraform.tfstate
 ```
 
-Supported URL schemes are `http`, `https`, `file`, `s3`(Amazon S3), `gs`(Google Cloud Storage), `remote`(Terraform Cloud) and `azurerm`(Azure Blob Storage).
+Supported URL schemes are `http`, `https`, `file`, `s3`(Amazon S3), and `remote`(Terraform Cloud).
 
 For more information, see [tfstate-lookup](https://github.com/fujiwara/tfstate-lookup).
 


### PR DESCRIPTION
## Summary
- Remove `gs`(Google Cloud Storage) and `azurerm`(Azure Blob Storage) from the supported tfstate URL schemes in README
- These backends were excluded in #114 but the documentation was not updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)