### PR TITLE
Fix panic in toJSON when marshaling ogen-generated types

### DIFF
--- a/app.go
+++ b/app.go
@@ -68,14 +68,14 @@ func toUpdateV1Application(app *Application, allTraffic bool) *v1.PatchApplicati
 	v.MinScale = v1.NewOptInt(app.MinScale)
 	v.MaxScale = v1.NewOptInt(app.MaxScale)
 	v.AllTrafficAvailable = v1.NewOptBool(allTraffic)
-	slog.Debug("toUpdateV1Application", "body", toJSON(v))
+	slog.Debug("toUpdateV1Application", "body", toJSON(app), "allTraffic", allTraffic)
 	return &v
 }
 
 func toJSON(v any) string {
 	b, err := json.Marshal(v)
 	if err != nil {
-		panic(err)
+		return fmt.Sprintf("<json marshal error: %s>", err)
 	}
 	return string(b)
 }
@@ -83,7 +83,7 @@ func toJSON(v any) string {
 func toJSONIndent(v any) string {
 	b, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
-		panic(err)
+		return fmt.Sprintf("<json marshal error: %s>", err)
 	}
 	return string(b)
 }


### PR DESCRIPTION
## Summary
- Fix panic in `toUpdateV1Application` debug log where `toJSON()` was called with ogen-generated `PatchApplicationBody` — `OptInt.MarshalJSON` returns empty bytes when `Set=false`, causing `json.Marshal` to fail
- Pass `Application` (plain struct) to debug log instead of `PatchApplicationBody`
- Replace `panic` with error message fallback in `toJSON` / `toJSONIndent` to prevent crashes in other call sites that also pass ogen types

🤖 Generated with [Claude Code](https://claude.com/claude-code)