### PR TITLE
Bump sakura-secrets-cli from 0.3.2 to 0.3.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/fatih/color v1.19.0
 	github.com/fujiwara/jsonnet-armed v0.1.1
-	github.com/fujiwara/sakura-secrets-cli v0.3.2
+	github.com/fujiwara/sakura-secrets-cli v0.3.3
 	github.com/fujiwara/tfstate-lookup v1.12.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-jsonnet v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fujiwara/jsonnet-armed v0.1.1 h1:Lq65mAKzhdVWFLjQowYb4t4RS/1AMA5sXiGWb6HaskM=
 github.com/fujiwara/jsonnet-armed v0.1.1/go.mod h1:MyGurW7aiBjqaRuXb1GsHGr43CbRkMJ8rg0zyYLd2CU=
-github.com/fujiwara/sakura-secrets-cli v0.3.2 h1:W3eWGDlFIuOtWyLD/Tp/aZGCPN4CSEoSkGlFoNrvfQo=
-github.com/fujiwara/sakura-secrets-cli v0.3.2/go.mod h1:5k1Hk7CLYY3dHmKKKDp4gkOoz5xIKZJHSW35pvPyq/8=
+github.com/fujiwara/sakura-secrets-cli v0.3.3 h1:HvodeXD3BTNoPJ4fctINkurH5O8uG4f0a+lzsm2PRVY=
+github.com/fujiwara/sakura-secrets-cli v0.3.3/go.mod h1:pQFzlX41C6916WOelLwV51zKuejvEj1RQNZj27/YZmQ=
 github.com/fujiwara/tfstate-lookup v1.12.1 h1:WQ0/+wYDm5yeiQtfejriKHonIXH6DSGkCJXEX8cV3hw=
 github.com/fujiwara/tfstate-lookup v1.12.1/go.mod h1:c7Nd3ZdQ2UljabuWzhgDaseKZhdXfgs6YLFarGbXyDs=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -252,8 +252,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sacloud/sacloud-sdk-go v0.0.1-beta.2 h1:aYN2S6belr8beyScK3ryPuekxLAxPS3WeCdppts1Wxk=
 github.com/sacloud/sacloud-sdk-go v0.0.1-beta.2/go.mod h1:nEoCmGgGzak+nx6PeQ1zkr5LiRhUWwwCb7kSig11210=
-github.com/sacloud/sakumock v0.4.0 h1:SzgFT+OYSPEOXBaootgVo58QpFe54vph7WnZiEcvmO4=
-github.com/sacloud/sakumock v0.4.0/go.mod h1:9KmiUAelti+6T2PCidG3a/OesteS9vqioWj/tiMhHAQ=
+github.com/sacloud/sakumock v0.6.0 h1:u5MqXDCfTYAX270J9reyhypc2CGkQ8bmxpjSK61hpn4=
+github.com/sacloud/sakumock v0.6.0/go.mod h1:9KmiUAelti+6T2PCidG3a/OesteS9vqioWj/tiMhHAQ=
 github.com/schollz/progressbar/v3 v3.19.0 h1:Ea18xuIRQXLAUidVDox3AbwfUhD0/1IvohyTutOIFoc=
 github.com/schollz/progressbar/v3 v3.19.0/go.mod h1:IsO3lpbaGuzh8zIMzgY3+J8l4C8GjO0Y9S69eFvNsec=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=


### PR DESCRIPTION
Updates sakura-secrets-cli to v0.3.3, which sends `Version` as null instead of 0 when unveiling the latest secret. The Secret Manager API started rejecting `Version: 0` with HTTP 422 (since 2026-07-16), so the Jsonnet `secret()` native function was failing when no version was specified. See fujiwara/sakura-secrets-cli#46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)